### PR TITLE
Added message integrity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Returns a new Bot instance.
 
 * `token` - String: Your Page Access Token, found in your App settings. Required.
 * `verify` - String: A verification token for the first-time setup of your webhook. If specified, `bot.middleware()` will also mount the `bot.verify()` middleware, as seen below. Optional.
+* `app_secret` - String: Your App Secret token used for message integrity check. If specified, every POST request  will be tested for spoofing. Optional.
 
 #### `bot.verify(secret)`
 

--- a/example/echo.js
+++ b/example/echo.js
@@ -3,7 +3,8 @@ const Bot = require('../')
 
 let bot = new Bot({
   token: 'PAGE_TOKEN',
-  verify: 'VERIFY_TOKEN'
+  verify: 'VERIFY_TOKEN',
+  app_secret: 'APP_SECRET'
 })
 
 bot.on('message', (payload, reply) => {

--- a/index.js
+++ b/index.js
@@ -74,10 +74,14 @@ class Bot extends EventEmitter {
 
   middleware () {
     return (req, res) => {
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      if (req.url === '/_status') return res.end(JSON.stringify({status: 'ok'}))
-      if (this.verify_token && req.method === 'GET') return this.verify(this.verify_token)(req, res)
-      if (req.method !== 'POST') return res.end()
+      if (req.method !== 'POST') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        if (req.url === '/_status') return res.end(JSON.stringify({status: 'ok'}))
+        else if (this.verify_token && req.method === 'GET') return this.verify(this.verify_token)(req, res)
+        else res.end()
+        return
+      }
+
       let body = ''
 
       req.on('data', (chunk) => {
@@ -94,13 +98,13 @@ class Bot extends EventEmitter {
 
           if (req.headers['x-hub-signature'] !== 'sha1=' + hmac.read()) {
             // we should probably write BadRequest or similar header
+            res.writeHead(400)
             res.end()
             return
           }
         }
 
         let parsed = JSON.parse(body)
-
         let entries = parsed.entry
 
         entries.forEach((entry) => {
@@ -123,7 +127,7 @@ class Bot extends EventEmitter {
             }
           })
         })
-
+        res.writeHead(200, { 'Content-Type': 'application/json' })
         res.end(JSON.stringify({status: 'ok'}))
       })
     }

--- a/index.js
+++ b/index.js
@@ -14,9 +14,7 @@ class Bot extends EventEmitter {
       throw new Error('Missing page token. See FB documentation for details: https://developers.facebook.com/docs/messenger-platform/quickstart')
     }
     this.token = opts.token
-    if (opts.app_secret) {
-      this.app_secret = opts.app_secret
-    }
+    this.app_secret = opts.app_secret || false
     this.verify_token = opts.verify || false
   }
 


### PR DESCRIPTION
Currently the endpoint is exposed to anyone and is vulnerable to message spoofing. While the recipient ID is probably unique (I have not tested if works across page tokens tho) it's still a good practice to verify that the message comes from the safe source.

I'm not happy with the commit and it's quite a draft. We should probably send a proper header code denying spoofed request. 

Facebook reference which this PR is based on is available here: https://developers.facebook.com/docs/graph-api/webhooks#receiveupdates (one needs to scroll down a bit).