### PR TITLE
Decouple message handling from middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 .nyc_output/
 coverage/
+npm-debug.log

--- a/example/echo-express.js
+++ b/example/echo-express.js
@@ -1,7 +1,7 @@
 'use strict'
 const http = require('http')
 const express = require('express')
-const bodyParser = require('body-parser');
+const bodyParser = require('body-parser')
 const Bot = require('../')
 
 let bot = new Bot({
@@ -30,10 +30,10 @@ bot.on('message', (payload, reply) => {
 
 let app = express()
 
-app.use(bodyParser.json());
+app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({
   extended: true
-}));
+}))
 
 app.get('/', (req, res) => {
   return bot._verify(req, res)

--- a/example/echo-express.js
+++ b/example/echo-express.js
@@ -1,0 +1,47 @@
+'use strict'
+const http = require('http')
+const express = require('express')
+const bodyParser = require('body-parser');
+const Bot = require('../')
+
+let bot = new Bot({
+  token: 'PAGE_TOKEN',
+  verify: 'VERIFY_TOKEN',
+  app_secret: 'APP_SECRET'
+})
+
+bot.on('error', (err) => {
+  console.log(err.message)
+})
+
+bot.on('message', (payload, reply) => {
+  let text = payload.message.text
+
+  bot.getProfile(payload.sender.id, (err, profile) => {
+    if (err) throw err
+
+    reply({ text }, (err) => {
+      if (err) throw err
+
+      console.log(`Echoed back to ${profile.first_name} ${profile.last_name}: ${text}`)
+    })
+  })
+})
+
+let app = express()
+
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({
+  extended: true
+}));
+
+app.get('/', (req, res) => {
+  return bot._verify(req, res)
+})
+
+app.post('/', (req, res) => {
+  bot._handleMessage(req.body.entry)
+  res.end(JSON.stringify({status: 'ok'}))
+})
+
+http.createServer(app).listen(3000)

--- a/index.js
+++ b/index.js
@@ -85,31 +85,36 @@ class Bot extends EventEmitter {
         }
 
         let parsed = JSON.parse(body)
-        let entries = parsed.entry
+        this._handleMessage(parsed)
 
-        entries.forEach((entry) => {
-          let events = entry.messaging
-
-          events.forEach((event) => {
-            // handle inbound messages
-            if (event.message) {
-              this._handleEvent('message', event)
-            }
-
-            // handle postbacks
-            if (event.postback) {
-              this._handleEvent('postback', event)
-            }
-
-            // handle message delivered
-            if (event.delivery) {
-              this._handleEvent('delivery', event)
-            }
-          })
-        })
         res.end(JSON.stringify({status: 'ok'}))
       })
     }
+  }
+
+  _handleMessage (json) {
+    let entries = json.entry
+
+    entries.forEach((entry) => {
+      let events = entry.messaging
+
+      events.forEach((event) => {
+        // handle inbound messages
+        if (event.message) {
+          this._handleEvent('message', event)
+        }
+
+        // handle postbacks
+        if (event.postback) {
+          this._handleEvent('postback', event)
+        }
+
+        // handle message delivered
+        if (event.delivery) {
+          this._handleEvent('delivery', event)
+        }
+      })
+    })
   }
 
   _verify (req, res) {


### PR DESCRIPTION
@remixz Thanks this is really nice!

**Issue** 
I'd like to be able to use this bot within an app that has existing middleware.

**Fix** 
Pull out the logic that handles incoming json from the ```middleware``` function. This allows for the server to be instantiated like so:

```js
let app = express()

app.get('/', (req, res) => {
  return bot._verify(req, res)
})

app.post('/', (req, res) => {
  bot._handleMessage(req.body.entry)
  res.end(JSON.stringify({status: 'ok'}))
})

http.createServer(app).listen(3000)
```
while keeping the current implementation intact.

Thanks!