### PR TITLE
Added authentication event, fixes #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,6 +113,11 @@ class Bot extends EventEmitter {
         if (event.delivery) {
           this._handleEvent('delivery', event)
         }
+
+        // handle authentication
+        if (event.optin) {
+          this._handleEvent('authentication', event)
+        }
       })
     })
   }


### PR DESCRIPTION
As it turns out the authentication callback guarantees _optin_ parameter making this event trivial to detect:

With empty _data-ref_:
```json
{
	"object": "page",
	"entry": [{
		"id": 510249619162304,
		"time": 1461167227231,
		"messaging": [{
			"sender": {
				"id": 1066835436691078
			},
			"recipient": {
				"id": 510249619162304
			},
			"timestamp": 1461167227231,
			"optin": {
				"ref": ""
			}
		}]
	}]
}
```