### PR TITLE
feat: add methods to set/remove persistent menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ Sends a message with the `payload` to the target `recipient`, and calls the call
 * `payload` - Object: The message payload. Should follow the [Send API format](https://developers.facebook.com/docs/messenger-platform/send-api-reference).
 * `callback` - Function: Called with `(err, info)` once the request has completed. `err` contains an error, if any, and `info` contains the response from Facebook, usually with the new message's ID.
 
+#### `bot.setPersistentMenu(buttons, callback)`
+
+Sets the persistent menu for the bot with the given buttons. See [Persistent Menu API](https://developers.facebook.com/docs/messenger-platform/thread-settings/persistent-menu)
+
+* `buttons` - Array: The Call to action buttons. Should be an array of [menu_items](https://developers.facebook.com/docs/messenger-platform/thread-settings/persistent-menu#menu_item)
+
 #### `bot.getProfile(target, callback)`
 
 Returns profile information of the `target`, called in the `callback`. See [User Profile API](https://developers.facebook.com/docs/messenger-platform/send-api-reference#user_profile_request).

--- a/index.js
+++ b/index.js
@@ -58,6 +58,49 @@ class Bot extends EventEmitter {
     })
   }
 
+  setPersistentMenu (buttons, cb) {
+    if (!cb) cb = Function.prototype
+
+    request({
+      method: 'POST',
+      url: 'https://graph.facebook.com/v2.6/me/thread_settings',
+      qs: {
+        access_token: this.token
+      },
+      json: {
+        setting_type: 'call_to_actions',
+        thread_state: 'existing_thread',
+        call_to_actions: buttons
+      }
+    }, (err, res, body) => {
+      if (err) return cb(err)
+      if (body.error) return cb(body.error)
+
+      cb(null, body)
+    })
+  }
+
+  removePersistentMenu (cb) {
+    if (!cb) cb = Function.prototype
+
+    request({
+      method: 'DELETE',
+      url: 'https://graph.facebook.com/v2.6/me/thread_settings',
+      qs: {
+        access_token: this.token
+      },
+      json: {
+        setting_type: 'call_to_actions',
+        thread_state: 'existing_thread'
+      }
+    }, (err, res, body) => {
+      if (err) return cb(err)
+      if (body.error) return cb(body.error)
+
+      cb(null, body)
+    })
+  }
+
   middleware () {
     return (req, res) => {
       // we always write 200, otherwise facebook will keep retrying the request

--- a/test/persistent-menu.js
+++ b/test/persistent-menu.js
@@ -1,0 +1,61 @@
+'use strict'
+const tap = require('tap')
+const nock = require('nock')
+const Bot = require('../')
+
+tap.test('bot.setPersistentMenu()', (t) => {
+  let bot = new Bot({
+    token: 'foo'
+  })
+
+  const buttons = {
+    type: 'postback',
+    title: 'help',
+    payload: 'HELP'
+  }
+
+  const payload = {
+    setting_type: 'call_to_actions',
+    thread_state: 'existing_thread',
+    call_to_actions: buttons
+  }
+
+  const response = {
+    result: 'Successfully added structured menu CTAs'
+  }
+
+  nock('https://graph.facebook.com').post('/v2.6/me/thread_settings', payload).query({
+    access_token: 'foo'
+  }).reply(200, response)
+
+  bot.setPersistentMenu(buttons, (err, body) => {
+    t.error(err, 'response should not be error')
+    t.deepEquals(body, response, 'response is correct')
+    t.end()
+  })
+})
+
+tap.test('bot.removePersistentMenu()', (t) => {
+  let bot = new Bot({
+    token: 'foo'
+  })
+
+  const payload = {
+    setting_type: 'call_to_actions',
+    thread_state: 'existing_thread'
+  }
+
+  const response = {
+    result: 'Successfully deleted structured menu CTAs'
+  }
+
+  nock('https://graph.facebook.com').delete('/v2.6/me/thread_settings', payload).query({
+    access_token: 'foo'
+  }).reply(200, response)
+
+  bot.removePersistentMenu((err, body) => {
+    t.error(err, 'response should not be error')
+    t.deepEquals(body, response, 'response is correct')
+    t.end()
+  })
+})


### PR DESCRIPTION
Add the ability to set/remove [Persistent Menu](https://developers.facebook.com/docs/messenger-platform/thread-settings/persistent-menu)