### PR TITLE
error output fix in example

### DIFF
--- a/example/echo-express.js
+++ b/example/echo-express.js
@@ -21,7 +21,7 @@ bot.on('message', (payload, reply) => {
     if (err) throw err
 
     reply({ text }, (err) => {
-      if (err) throw err
+      if (err) throw JSON.stringify(err)
 
       console.log(`Echoed back to ${profile.first_name} ${profile.last_name}: ${text}`)
     })


### PR DESCRIPTION
since `err` is object, it will output "[object Object]" instead of useful error message.