### PR TITLE
Added `messaging_type` breaking change fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,12 @@ http.createServer(bot.middleware()).listen(3000)
 
 As well, it mounts `/_status`, which will return `{"status": "ok"}` if the middleware is running. If `verify` is specified in the bot options, it will mount a handler for `GET` requests that verifies the webhook.
 
-#### `bot.sendMessage(recipient, payload, [callback])`
+#### `bot.sendMessage(recipient, messagingType, payload, [callback])`
 
 Sends a message with the `payload` to the target `recipient`, and calls the callback if any. Returns a promise. See [Send API](https://developers.facebook.com/docs/messenger-platform/send-api-reference#request).
 
 * `recipient` - Number: The Facebook ID of the intended recipient.
+* `messagingType` - string: One of the available Facebook [messaging_types](https://developers.facebook.com/docs/messenger-platform/send-messages#messaging_types)
 * `payload` - Object: The message payload. Should follow the [Send API format](https://developers.facebook.com/docs/messenger-platform/send-api-reference).
 * `callback` - (Optional) Function: Called with `(err, info)` once the request has completed. `err` contains an error, if any, and `info` contains the response from Facebook, usually with the new message's ID.
 
@@ -151,7 +152,7 @@ The underlying method used by `bot.middleware()` for the initial webhook verific
 Triggered when a message is sent to the bot.
 
 * `payload` - Object: An object containing the message event's payload from Facebook. See [Facebook's documentation](https://developers.facebook.com/docs/messenger-platform/webhook-reference#received_message) for the format.
-* `reply` - Function: A convenience function that calls `bot.sendMessage`, with the recipient automatically set to the message sender's Facebook ID. Example usage:
+* `reply` - Function: A convenience function that calls `bot.sendMessage`, with the recipient automatically set to the message sender's Facebook ID, and the **messaging_type** set to `RESPONSE`. Example usage:
 
 ```js
 bot.on('message', (payload, reply, actions) => {
@@ -166,7 +167,7 @@ bot.on('message', (payload, reply, actions) => {
 Triggered when a postback is triggered by the sender in Messenger.
 
 * `payload` - Object: An object containing the postback event's payload from Facebook. See [Facebook's documentation](https://developers.facebook.com/docs/messenger-platform/webhook-reference#postback) for the format.
-* `reply` - Function: A convenience function that calls `bot.sendMessage`, with the recipient automatically set to the message sender's Facebook ID. Example usage:
+* `reply` - Function: A convenience function that calls `bot.sendMessage`, with the recipient automatically set to the message sender's Facebook ID, and the **messaging_type** set to `RESPONSE`. Example usage:
 * `actions` - Object: An object with two functions: `setTyping(status: Boolean)`, and `markRead()`.
 
 ```js
@@ -180,7 +181,7 @@ bot.on('postback', (payload, reply, actions) => {
 Triggered when a message has been successfully delivered.
 
 * `payload` - Object: An object containing the delivery event's payload from Facebook. See [Facebook's documentation](https://developers.facebook.com/docs/messenger-platform/webhook-reference#message_delivery) for the format.
-* `reply` - Function: A convenience function that calls `bot.sendMessage`, with the recipient automatically set to the message sender's Facebook ID. Example usage:
+* `reply` - Function: A convenience function that calls `bot.sendMessage`, with the recipient automatically set to the message sender's Facebook ID, and the **messaging_type** set to `RESPONSE`. Example usage:
 * `actions` - Object: An object with two functions: `setTyping(status: Boolean)`, and `markRead()`.
 
 ```js
@@ -194,7 +195,7 @@ bot.on('delivery', (payload, reply, actions) => {
 Triggered when a user authenticates with the "Send to Messenger" plugin.
 
 * `payload` - Object: An object containing the authentication event's payload from Facebook. See [Facebook's documentation](https://developers.facebook.com/docs/messenger-platform/webhook-reference#auth) for the format.
-* `reply` - Function: A convenience function that calls `bot.sendMessage`, with the recipient automatically set to the message sender's Facebook ID. Example usage:
+* `reply` - Function: A convenience function that calls `bot.sendMessage`, with the recipient automatically set to the message sender's Facebook ID, and the **messaging_type** set to `RESPONSE`. Example usage:
 * `actions` - Object: An object with two functions: `setTyping(status: Boolean)`, and `markRead()`.
 
 ```js
@@ -208,7 +209,7 @@ bot.on('authentication', (payload, reply, actions) => {
 Triggered when an m.me link is used with a referral param and only in a case this user already has a thread with this bot (for new threads see 'postback' event)
 
 * `payload` - Object: An object containing the authentication event's payload from Facebook. See [Facebook's documentation](https://developers.facebook.com/docs/messenger-platform/webhook-reference/referral) for the format.
-* `reply` - Function: A convenience function that calls `bot.sendMessage`, with the recipient automatically set to the message sender's Facebook ID. Example usage:
+* `reply` - Function: A convenience function that calls `bot.sendMessage`, with the recipient automatically set to the message sender's Facebook ID, and the **messaging_type** set to `RESPONSE`. Example usage:
 * `actions` - Object: An object with two functions: `setTyping(status: Boolean)`, and `markRead()`.
 
 ```js

--- a/README.md
+++ b/README.md
@@ -87,13 +87,13 @@ http.createServer(bot.middleware()).listen(3000)
 
 As well, it mounts `/_status`, which will return `{"status": "ok"}` if the middleware is running. If `verify` is specified in the bot options, it will mount a handler for `GET` requests that verifies the webhook.
 
-#### `bot.sendMessage(recipient, messagingType, payload, [callback])`
+#### `bot.sendMessage(recipient, payload, [messagingType], [callback])`
 
 Sends a message with the `payload` to the target `recipient`, and calls the callback if any. Returns a promise. See [Send API](https://developers.facebook.com/docs/messenger-platform/send-api-reference#request).
 
 * `recipient` - Number: The Facebook ID of the intended recipient.
-* `messagingType` - string: One of the available Facebook [messaging_types](https://developers.facebook.com/docs/messenger-platform/send-messages#messaging_types)
 * `payload` - Object: The message payload. Should follow the [Send API format](https://developers.facebook.com/docs/messenger-platform/send-api-reference).
+* `messagingType` - (Optional) string: One of the available Facebook [messaging_types](https://developers.facebook.com/docs/messenger-platform/send-messages#messaging_types). DefaultsTo `RESPONSE`
 * `callback` - (Optional) Function: Called with `(err, info)` once the request has completed. `err` contains an error, if any, and `info` contains the response from Facebook, usually with the new message's ID.
 
 #### `bot.sendSenderAction(recipient, senderAction, [callback])`

--- a/example/recognize-music/recognize.js
+++ b/example/recognize-music/recognize.js
@@ -1,6 +1,7 @@
 'use strict'
 const crypto = require('crypto')
 const request = require('request')
+const Buffer = require('safe-buffer')
 
 module.exports = function recognizeSong (opts, cb) {
   let attachment = opts.message.attachments[0]
@@ -32,7 +33,7 @@ module.exports = function recognizeSong (opts, cb) {
       if (err) return cb(err)
 
       if (body.status.code !== 0) {
-        return cb({message: 'NO_MATCH'})
+        return cb(new Error('NO_MATCH'))
       }
 
       let song = body.metadata.music[0]

--- a/index.js
+++ b/index.js
@@ -37,7 +37,11 @@ class Bot extends EventEmitter {
     })
   }
 
-  sendMessage (recipient, messagingType, payload, cb) {
+  sendMessage (recipient, payload, messagingType, cb) {
+    if (typeof messagingType === 'function' && cb === undefined) {
+      cb = messagingType
+      messagingType = 'RESPONSE'
+    }
     return request({
       method: 'POST',
       uri: 'https://graph.facebook.com/v2.6/me/messages',
@@ -277,7 +281,7 @@ class Bot extends EventEmitter {
   }
 
   _handleEvent (type, event) {
-    this.emit(type, event, this.sendMessage.bind(this, event.sender.id, 'RESPONSE'), this._getActionsObject(event))
+    this.emit(type, event, this.sendMessage.bind(this, event.sender.id), this._getActionsObject(event))
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -37,12 +37,13 @@ class Bot extends EventEmitter {
     })
   }
 
-  sendMessage (recipient, payload, cb) {
+  sendMessage (recipient, messagingType, payload, cb) {
     return request({
       method: 'POST',
       uri: 'https://graph.facebook.com/v2.6/me/messages',
       qs: this._getQs(),
       json: {
+        messaging_type: messagingType,
         recipient: { id: recipient },
         message: payload
       }
@@ -276,7 +277,7 @@ class Bot extends EventEmitter {
   }
 
   _handleEvent (type, event) {
-    this.emit(type, event, this.sendMessage.bind(this, event.sender.id), this._getActionsObject(event))
+    this.emit(type, event, this.sendMessage.bind(this, event.sender.id, 'RESPONSE'), this._getActionsObject(event))
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "messenger-bot",
+  "version": "2.4.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "homepage": "https://github.com/remixz/messenger-bot#readme",
   "dependencies": {
     "request": "^2.71.0",
-    "request-promise": "^4.1.1"
+    "request-promise": "^4.1.1",
+    "safe-buffer": "^5.1.1"
   },
   "devDependencies": {
     "nock": "^9.0.0",


### PR DESCRIPTION
> Beginning May 7, 2018 the messaging_type property will be required and all messages sent without it will not be delivered.

See https://developers.facebook.com/docs/messenger-platform/send-messages#messaging_types

**Edit:**
Fixed standard errors in `example` dir