### PR TITLE
Add possibility of sending message with tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,22 +87,15 @@ http.createServer(bot.middleware()).listen(3000)
 
 As well, it mounts `/_status`, which will return `{"status": "ok"}` if the middleware is running. If `verify` is specified in the bot options, it will mount a handler for `GET` requests that verifies the webhook.
 
-#### `bot.sendMessage(recipient, payload, [callback])`
+#### `bot.sendMessage(recipient, payload, [callback], [messagingType], [tag])`
 
 Sends a message with the `payload` to the target `recipient`, and calls the callback if any. Returns a promise. See [Send API](https://developers.facebook.com/docs/messenger-platform/send-api-reference#request).
 
 * `recipient` - Number: The Facebook ID of the intended recipient.
 * `payload` - Object: The message payload. Should follow the [Send API format](https://developers.facebook.com/docs/messenger-platform/send-api-reference).
 * `callback` - (Optional) Function: Called with `(err, info)` once the request has completed. `err` contains an error, if any, and `info` contains the response from Facebook, usually with the new message's ID.
-
-#### `bot.sendMessageWithTag(recipient, payload, tag, [callback])`
-
-Sends a message with the `payload` to the target `recipient`, and calls the callback if any. Returns a promise. See [Send API](https://developers.facebook.com/docs/messenger-platform/send-api-reference#request).
-
-* `recipient` - Number: The Facebook ID of the intended recipient.
-* `payload` - Object: The message payload. Should follow the [Send API format](https://developers.facebook.com/docs/messenger-platform/send-api-reference).
-* `tag` - String: The tag's message. [Supported Tags](https://developers.facebook.com/docs/messenger-platform/send-messages/message-tags#supported_tags).
-* `callback` - (Optional) Function: Called with `(err, info)` once the request has completed. `err` contains an error, if any, and `info` contains the response from Facebook, usually with the new message's ID.
+* `messagingType` - (Optional) String: The message type. [Supported Messaging Type](https://developers.facebook.com/docs/messenger-platform/send-messages#messaging_types).
+* `tag` - (Optional) String: The tag's message. [Supported Tags](https://developers.facebook.com/docs/messenger-platform/send-messages/message-tags#supported_tags).
 
 #### `bot.sendSenderAction(recipient, senderAction, [callback])`
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ Sends a message with the `payload` to the target `recipient`, and calls the call
 * `payload` - Object: The message payload. Should follow the [Send API format](https://developers.facebook.com/docs/messenger-platform/send-api-reference).
 * `callback` - (Optional) Function: Called with `(err, info)` once the request has completed. `err` contains an error, if any, and `info` contains the response from Facebook, usually with the new message's ID.
 
+#### `bot.sendMessageWithTag(recipient, payload, tag, [callback])`
+
+Sends a message with the `payload` to the target `recipient`, and calls the callback if any. Returns a promise. See [Send API](https://developers.facebook.com/docs/messenger-platform/send-api-reference#request).
+
+* `recipient` - Number: The Facebook ID of the intended recipient.
+* `payload` - Object: The message payload. Should follow the [Send API format](https://developers.facebook.com/docs/messenger-platform/send-api-reference).
+* `tag` - String: The tag's message. [Supported Tags](https://developers.facebook.com/docs/messenger-platform/send-messages/message-tags#supported_tags).
+* `callback` - (Optional) Function: Called with `(err, info)` once the request has completed. `err` contains an error, if any, and `info` contains the response from Facebook, usually with the new message's ID.
+
 #### `bot.sendSenderAction(recipient, senderAction, [callback])`
 
 Sends the sender action `senderAction` to the target `recipient`, and calls the callback if any. Returns a promise.

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ class Bot extends EventEmitter {
       })
   }
 
-  sendMessageWithTag (recipient, payload, tag, cb){
+  sendMessageWithTag (recipient, payload, tag, cb) {
     return this.sendMessage(recipient, payload, cb, tag)
   }
 

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ class Bot extends EventEmitter {
       })
   }
 
-  sendMessage (recipient, payload, cb, tag = null) {
+  sendMessage (recipient, payload, cb, messagingType = null, tag = null) {
     let options = {
       method: 'POST',
       uri: 'https://graph.facebook.com/v2.6/me/messages',
@@ -47,9 +47,16 @@ class Bot extends EventEmitter {
         message: payload
       }
     }
-    if (tag != null) {
-      options.json.messaging_type = 'MESSAGE_TAG'
-      options.json.tag = tag
+    if (messagingType === 'MESSAGE_TAG') {
+      if (tag != null) {
+        options.json.tag = tag
+      }
+      else {
+        cb(new Error('You must specify a Tag'))
+      }
+    }
+    if (messagingType != null) {
+      options.json.messaging_type = messagingType
     }
     return request(options)
       .then(body => {
@@ -59,12 +66,8 @@ class Bot extends EventEmitter {
       })
       .catch(err => {
         if (!cb) return Promise.reject(err)
-        cb(err)
-      })
-  }
-
-  sendMessageWithTag (recipient, payload, tag, cb) {
-    return this.sendMessage(recipient, payload, cb, tag)
+          cb(err)
+        })
   }
 
   sendSenderAction (recipient, senderAction, cb) {

--- a/index.js
+++ b/index.js
@@ -37,34 +37,34 @@ class Bot extends EventEmitter {
       })
   }
 
-  sendMessage (recipient, payload, cb, tag=null) {
-      let options = {
-          method: 'POST',
-          uri: 'https://graph.facebook.com/v2.6/me/messages',
-          qs: this._getQs(),
-          json: {
-              recipient: { id: recipient },
-              message: payload,
-          }
+  sendMessage (recipient, payload, cb, tag = null) {
+    let options = {
+      method: 'POST',
+      uri: 'https://graph.facebook.com/v2.6/me/messages',
+      qs: this._getQs(),
+      json: {
+        recipient: { id: recipient },
+        message: payload
       }
-      if(tag!=null){
-          options.json.messaging_type = "MESSAGE_TAG"
-          options.json.tag = tag
-      }
-      return request(options)
-          .then(body => {
-              if (body.error) return Promise.reject(body.error)
-              if (!cb) return body
-              cb(null, body)
-          })
-          .catch(err => {
-              if (!cb) return Promise.reject(err)
-              cb(err)
-          })
+    }
+    if (tag != null) {
+      options.json.messaging_type = 'MESSAGE_TAG'
+      options.json.tag = tag
+    }
+    return request(options)
+      .then(body => {
+        if (body.error) return Promise.reject(body.error)
+        if (!cb) return body
+        cb(null, body)
+      })
+      .catch(err => {
+        if (!cb) return Promise.reject(err)
+        cb(err)
+      })
   }
 
-  sendMessageWithTag(recipient, payload, tag, cb){
-      return this.sendMessage(recipient, payload, cb, tag)
+  sendMessageWithTag (recipient, payload, tag, cb){
+    return this.sendMessage(recipient, payload, cb, tag)
   }
 
   sendSenderAction (recipient, senderAction, cb) {

--- a/index.js
+++ b/index.js
@@ -50,8 +50,7 @@ class Bot extends EventEmitter {
     if (messagingType === 'MESSAGE_TAG') {
       if (tag != null) {
         options.json.tag = tag
-      }
-      else {
+      } else {
         cb(new Error('You must specify a Tag'))
       }
     }
@@ -66,8 +65,8 @@ class Bot extends EventEmitter {
       })
       .catch(err => {
         if (!cb) return Promise.reject(err)
-          cb(err)
-        })
+        cb(err)
+      })
   }
 
   sendSenderAction (recipient, senderAction, cb) {

--- a/index.js
+++ b/index.js
@@ -37,25 +37,34 @@ class Bot extends EventEmitter {
       })
   }
 
-  sendMessage (recipient, payload, cb) {
-    return request({
-      method: 'POST',
-      uri: 'https://graph.facebook.com/v2.6/me/messages',
-      qs: this._getQs(),
-      json: {
-        recipient: { id: recipient },
-        message: payload
+  sendMessage (recipient, payload, cb, tag=null) {
+      let options = {
+          method: 'POST',
+          uri: 'https://graph.facebook.com/v2.6/me/messages',
+          qs: this._getQs(),
+          json: {
+              recipient: { id: recipient },
+              message: payload,
+          }
       }
-    })
-      .then(body => {
-        if (body.error) return Promise.reject(body.error)
-        if (!cb) return body
-        cb(null, body)
-      })
-      .catch(err => {
-        if (!cb) return Promise.reject(err)
-        cb(err)
-      })
+      if(tag!=null){
+          options.json.messaging_type = "MESSAGE_TAG"
+          options.json.tag = tag
+      }
+      return request(options)
+          .then(body => {
+              if (body.error) return Promise.reject(body.error)
+              if (!cb) return body
+              cb(null, body)
+          })
+          .catch(err => {
+              if (!cb) return Promise.reject(err)
+              cb(err)
+          })
+  }
+
+  sendMessageWithTag(recipient, payload, tag, cb){
+      return this.sendMessage(recipient, payload, cb, tag)
   }
 
   sendSenderAction (recipient, senderAction, cb) {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,15 @@
   "devDependencies": {
     "nock": "^9.0.0",
     "standard": "^11.0.1",
-    "tap": "=11.9.0"
+    "tap": {
+      "version": "11.1.5",
+      "from": "tap@11.1.5",
+      "dependencies": {
+        "nyc": {
+          "version": "11.9.0",
+          "from": "nyc@11.9.0"
+        }
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   "devDependencies": {
     "nock": "^9.0.0",
     "standard": "^11.0.1",
-    "tap": "^11.1.5"
+    "tap": "=11.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,15 +29,6 @@
   "devDependencies": {
     "nock": "^9.0.0",
     "standard": "^11.0.1",
-    "tap": {
-      "version": "11.1.5",
-      "from": "tap@11.1.5",
-      "dependencies": {
-        "nyc": {
-          "version": "11.9.0",
-          "from": "nyc@11.9.0"
-        }
-      }
-    }
+    "tap": "10.7.3"
   }
 }


### PR DESCRIPTION
Add the function `sendMessageWithTag(recipient, payload, tag, cb)` which allows sending messages with the specified tag.

Example of usage : 
``` Node
bot.sendMessageWithTag(payload.sender.id, { "text": "message_test"}, "NON_PROMOTIONAL_SUBSCRIPTION", (error, body) => {
    // ...
});