### PR TITLE
Add Attachment Upload API method

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ Sends a message with the `payload` to the target `recipient`, and calls the call
 * `payload` - Object: The message payload. Should follow the [Send API format](https://developers.facebook.com/docs/messenger-platform/send-api-reference).
 * `callback` - (Optional) Function: Called with `(err, info)` once the request has completed. `err` contains an error, if any, and `info` contains the response from Facebook, usually with the new message's ID.
 
+#### `bot.getAttachmentUploadId(url, is_reusable, type, [callback])`
+
+Sends the media to the Attachment Upload API and calls the callback if the upload is successful, including the `attachment_id`. See [Attachment Upload API](https://developers.facebook.com/docs/messenger-platform/reference/attachment-upload-api).
+
+* `url` - String: Link where can be fetched the media.
+* `is_reusable` - Boolean: Defined if the saved asset will be sendable to other message recipients.
+* `type` - String: The type of media. Can be one of: `image`, `video`, `audio`, `file`.
+* `callback` - (Optional) Function: Called with `(err, info)` once the request has completed. `err` contains an error, if any, and `info` contains the response from Facebook, usually with the media's ID.
+
 #### `bot.sendSenderAction(recipient, senderAction, [callback])`
 
 Sends the sender action `senderAction` to the target `recipient`, and calls the callback if any. Returns a promise.

--- a/index.js
+++ b/index.js
@@ -120,33 +120,33 @@ class Bot extends EventEmitter {
         cb(err)
       })
   }
-  
-  getAttachmentUploadId (url, is_reusable, type, cb) {
-      return request({
-          method: 'POST',
-          uri: 'https://graph.facebook.com/v2.6/me/message_attachments',
-          qs: this._getQs(),
-          json: {
-              message:{
-                  attachment:{
-                      type: type,
-                      payload:{
-                          is_reusable: is_reusable,
-                          url: url
-                      }
-                  }
-              }
+
+  getAttachmentUploadId (url, isReusable, type, cb) {
+    return request({
+      method: 'POST',
+      uri: 'https://graph.facebook.com/v2.6/me/message_attachments',
+      qs: this._getQs(),
+      json: {
+        message: {
+          attachment: {
+            type: type,
+            payload: {
+              is_reusable: isReusable,
+              url: url
+            }
           }
+        }
+      }
+    })
+      .then(body => {
+        if (body.error) return Promise.reject(body.error)
+        if (!cb) return body
+        cb(null, body)
       })
-          .then(body => {
-              if (body.error) return Promise.reject(body.error)
-              if (!cb) return body
-              cb(null, body)
-          })
-          .catch(err => {
-              if (!cb) return Promise.reject(err)
-              cb(err)
-          })
+      .catch(err => {
+        if (!cb) return Promise.reject(err)
+        cb(err)
+      })
   }
 
   setGetStartedButton (payload, cb) {

--- a/index.js
+++ b/index.js
@@ -120,6 +120,34 @@ class Bot extends EventEmitter {
         cb(err)
       })
   }
+  
+  getAttachmentUploadId (url, is_reusable, type, cb) {
+      return request({
+          method: 'POST',
+          uri: 'https://graph.facebook.com/v2.6/me/message_attachments',
+          qs: this._getQs(),
+          json: {
+              message:{
+                  attachment:{
+                      type: type,
+                      payload:{
+                          is_reusable: is_reusable,
+                          url: url
+                      }
+                  }
+              }
+          }
+      })
+          .then(body => {
+              if (body.error) return Promise.reject(body.error)
+              if (!cb) return body
+              cb(null, body)
+          })
+          .catch(err => {
+              if (!cb) return Promise.reject(err)
+              cb(err)
+          })
+  }
 
   setGetStartedButton (payload, cb) {
     return this.setField('get_started', payload, cb)


### PR DESCRIPTION
Add the method `getAttachmentUploadId()` which allows sending files with external urls. It uses the [Facebook Attachment Upload API](https://developers.facebook.com/docs/messenger-platform/reference/attachment-upload-api?locale=en_US).

You can use it as below:
```Javascript
bot.getAttachmentUploadId("https://images.pexels.com/photos/63324/california-road-highway-mountains-63324.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", true, "image", (err, body) => {
    // ...
});
```
