### PR TITLE
Add possibility of unlinking an account

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ Sends the sender action `senderAction` to the target `recipient`, and calls the 
 * `senderAction` - String: The sender action to execute. Can be one of: `typing_on`, 'typing_off', 'mark_seen'. See the [Sender Actions API reference](https://developers.facebook.com/docs/messenger-platform/send-api-reference/sender-actions) for more information.
 * `callback` - (Optional) Function: Called with `(err, info)` once the request has completed. `err` contains an error, if any, and `info` contains the response from Facebook, usually with the new message's ID.
 
+#### `bot.unlinkAccount(psid, [callback])`
+
+Unlinks the user with the corresponding `psid`, and calls the callback if any. Returns a promise. See [Account Unlink Endpoint].(https://developers.facebook.com/docs/messenger-platform/identity/account-linking?locale=en_US#unlink)
+
+* `psid` - Number: The Facebook ID of the user who has to be logged out.
+* `callback` - (Optional) Function: Called with `(err, info)` once the request has completed. `err` contains an error, if any, and `info` contains the response from Facebook.
+
 #### `bot.setGetStartedButton(payload, [callback])`
 #### `bot.setPersistentMenu(payload, [callback])`
 

--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ class Bot extends EventEmitter {
         cb(err)
       })
   }
-  
+
   getAttachmentUploadId (url, isReusable, type, cb) {
     return request({
       method: 'POST',

--- a/index.js
+++ b/index.js
@@ -121,6 +121,26 @@ class Bot extends EventEmitter {
       })
   }
 
+  unlinkAccount (psid, cb) {
+    return request({
+      method: 'POST',
+      uri: 'https://graph.facebook.com/v2.6/me/unlink_accounts',
+      qs: this._getQs(),
+      json: {
+        psid : psid
+      }
+    })
+      .then(body => {
+        if (body.error) return Promise.reject(body.error)
+        if (!cb) return body
+        cb(null, body)
+      })
+      .catch(err => {
+        if (!cb) return Promise.reject(err)
+        cb(err)
+      })
+  }
+
   setGetStartedButton (payload, cb) {
     return this.setField('get_started', payload, cb)
   }

--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ class Bot extends EventEmitter {
       uri: 'https://graph.facebook.com/v2.6/me/unlink_accounts',
       qs: this._getQs(),
       json: {
-        psid : psid
+        psid: psid
       }
     })
       .then(body => {


### PR DESCRIPTION
Add a function called `unlinkAccount()` which unlink the user account as explained there: https://developers.facebook.com/docs/messenger-platform/identity/account-linking?locale=en_US#unlink.

It takes as parameters the `PSID` of the user who has to be logged out and the usual callback.